### PR TITLE
Update nightly toolchain version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
   include:
     - rust: stable
     - rust: beta
-    - rust: nightly-2019-02-22
+    - rust: nightly-2019-03-15
       env:
         - CARGO_INCREMENTAL=0
         - RUSTFLAGS='-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads'


### PR DESCRIPTION
According to the [Rustup packages availability overview](https://rust-lang.github.io/rustup-components-history/index.html) this is the latest nightly toolchain version that ships with `rls`, `clippy`, and `rustfmt`.